### PR TITLE
fix:Make Total Token throughput case insensitive

### DIFF
--- a/inference/serving/vLLM/vllm_perf.sh
+++ b/inference/serving/vLLM/vllm_perf.sh
@@ -77,7 +77,7 @@ for PAIR in "${IO_PAIRS[@]}"; do
             /Total generated tokens/ {tg=clean($NF)}
             /Request throughput/ {rt=clean($NF)}
             /Output token throughput/ {ot=clean($NF)}
-            /Total Token throughput/ {tt=clean($NF)}
+            /Total Token throughput/i {tt=clean($NF)}
             /Mean TTFT/ {mttft=clean($NF)}
             /Median TTFT/ {medttft=clean($NF)}
             /P95 TTFT/ {p95ttft=clean($NF)}


### PR DESCRIPTION
The "Total Token throughput" has changed to "Total token throughput" in vLLM 0.13.0.